### PR TITLE
Automatically use strongest TLS version

### DIFF
--- a/pymumble_py3/mumble.py
+++ b/pymumble_py3/mumble.py
@@ -127,7 +127,7 @@ class Mumble(threading.Thread):
         std_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
         try:
-            self.control_socket = ssl.wrap_socket(std_sock, certfile=self.certfile, keyfile=self.keyfile, ssl_version=ssl.PROTOCOL_TLSv1)
+            self.control_socket = ssl.wrap_socket(std_sock, certfile=self.certfile, keyfile=self.keyfile, ssl_version=ssl.PROTOCOL_TLS)
             self.control_socket.connect((self.host, self.port))
             self.control_socket.setblocking(0)
 


### PR DESCRIPTION
pymumble currently enforces the usage of TLSv1 while Murmur supports at least TLSv1.2

Setting just PROTOCOL_TLS should allow Murmur to negotiate the version with pymumble
https://docs.python.org/3/library/ssl.html#ssl.wrap_socket