### PR TITLE
 Raise an error when trying to send too long text messages

### DIFF
--- a/pymumble_py3/channels.py
+++ b/pymumble_py3/channels.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from .constants import *
 from threading import Lock
-from .errors import UnknownChannelError
+from .errors import UnknownChannelError, TextTooLongError
 from . import messages
 
 
@@ -139,26 +139,31 @@ class Channel(dict):
         if name not in self or self[name] != field:
             self[name] = field
             actions[name] = field
-            
+
         return actions  # return a dict with updates performed, useful for the callback functions
-    
+
     def get_property(self, property):
         if property in self:
             return self[property]
         else:
             return None
-        
+
     def move_in(self, session=None):
         """Ask to move a session in a specific channel.  By default move pymumble own session"""
         if session is None:
             session = self.mumble_object.users.myself_session
-        
+
         cmd = messages.MoveCmd(session, self["channel_id"])
         self.mumble_object.execute_command(cmd)
-    
+
 
     def send_text_message(self, message):
         """Send a text message to the channel."""
+
+        # TODO: This check should be done inside execute_command()
+        if len(message) > self.mumble_object.get_max_message_length():
+            raise TextTooLongError(self.mumble_object.get_max_message_length())
+
         session = self.mumble_object.users.myself_session
 
         cmd = messages.TextMessage(session, self["channel_id"], message)

--- a/pymumble_py3/channels.py
+++ b/pymumble_py3/channels.py
@@ -161,6 +161,8 @@ class Channel(dict):
         """Send a text message to the channel."""
 
         # TODO: This check should be done inside execute_command()
+        # However, this is currently not possible because execute_command() does
+        # not actually execute the command.
         if len(message) > self.mumble_object.get_max_message_length():
             raise TextTooLongError(self.mumble_object.get_max_message_length())
 

--- a/pymumble_py3/errors.py
+++ b/pymumble_py3/errors.py
@@ -62,3 +62,11 @@ class InvalidVarInt(Exception):
 
     def __str__(self):
         return repr(self.value)
+
+class TextTooLongError(Exception):
+    """Throwned when trying to send a message which is longer than allowed"""
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return 'Maximum allowed length: {}'.format(self.value)

--- a/pymumble_py3/errors.py
+++ b/pymumble_py3/errors.py
@@ -2,7 +2,7 @@
 
 
 class CodecNotSupportedError(Exception):
-    """Throwned when receiving an audio packet from an unsupported codec"""
+    """Thrown when receiving an audio packet from an unsupported codec"""
     def __init__(self, value):
         self.value = value
 
@@ -11,7 +11,7 @@ class CodecNotSupportedError(Exception):
 
 
 class ConnectionRejectedError(Exception):
-    """Throwned when server reject the connection"""
+    """Thrown when server reject the connection"""
     def __init__(self, value):
         self.value = value
 
@@ -20,7 +20,7 @@ class ConnectionRejectedError(Exception):
 
 
 class InvalidFormatError(Exception):
-    """Throwned when receiving a packet not understood"""
+    """Thrown when receiving a packet not understood"""
     def __init__(self, value):
         self.value = value
 
@@ -29,7 +29,7 @@ class InvalidFormatError(Exception):
 
 
 class UnknownCallbackError(Exception):
-    """Throwned when asked for an unknown callback"""
+    """Thrown when asked for an unknown callback"""
     def __init__(self, value):
         self.value = value
 
@@ -38,25 +38,25 @@ class UnknownCallbackError(Exception):
 
 
 class UnknownChannelError(Exception):
-    """Throwned when using an unknown channel"""
+    """Thrown when using an unknown channel"""
     def __init__(self, value):
         self.value = value
 
     def __str__(self):
         return repr(self.value)
-    
+
 
 class InvalidSoundDataError(Exception):
-    """Throwned when trying to send an invalid audio pcm data"""
+    """Thrown when trying to send an invalid audio pcm data"""
     def __init__(self, value):
         self.value = value
 
     def __str__(self):
         return repr(self.value)
-    
+
 
 class InvalidVarInt(Exception):
-    """Throwned when trying to decode an invalid varint"""
+    """Thrown when trying to decode an invalid varint"""
     def __init__(self, value):
         self.value = value
 
@@ -64,7 +64,7 @@ class InvalidVarInt(Exception):
         return repr(self.value)
 
 class TextTooLongError(Exception):
-    """Throwned when trying to send a message which is longer than allowed"""
+    """Thrown when trying to send a message which is longer than allowed"""
     def __init__(self, value):
         self.value = value
 

--- a/pymumble_py3/users.py
+++ b/pymumble_py3/users.py
@@ -210,6 +210,8 @@ class User(dict):
         """Send a text message to the user."""
 
         # TODO: This check should be done inside execute_command()
+        # However, this is currently not possible because execute_command() does
+        # not actually execute the command.
         if len(message) > self.mumble_object.get_max_message_length():
             raise TextTooLongError(self.mumble_object.get_max_message_length())
 

--- a/pymumble_py3/users.py
+++ b/pymumble_py3/users.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from .constants import *
+from .errors import TextTooLongError
 from threading import Lock
 from . import soundqueue
 from . import messages
@@ -207,5 +208,10 @@ class User(dict):
 
     def send_message(self, message):
         """Send a text message to the user."""
+
+        # TODO: This check should be done inside execute_command()
+        if len(message) > self.mumble_object.get_max_message_length():
+            raise TextTooLongError(self.mumble_object.get_max_message_length())
+
         cmd = messages.TextPrivateMessage(self["session"], message)
         self.mumble_object.execute_command(cmd)


### PR DESCRIPTION
During the connection phase the mumble server tells each client the maximum allowed length of text messages. This PR now enforces this max length limit by raising a `TextTooLongError` error. Additionally, a user can use the `Mumble.get_max_message_length()` method to determine the max allowed length in advance.