### PR TITLE
Add get_users() method to Channel object

### DIFF
--- a/API.md
+++ b/API.md
@@ -251,6 +251,7 @@ Send message into the specific channel.
 > `Channel.get_users()`
 
 List all users currently in channel.
+After moving into a channel, it's normal to not have the list of user. Pymumble need few ms to update the list.
 
 ## SoundOutput object (accessible through Mumble.sound_output)
 Takes care of encoding, packetizing and sending the audio to the server.

--- a/API.md
+++ b/API.md
@@ -248,6 +248,10 @@ If no session specified, try to move the library application itself.
 
 Send message into the specific channel.
 
+> `Channel.get_users()`
+
+List all users currently in channel.
+
 ## SoundOutput object (accessible through Mumble.sound_output)
 Takes care of encoding, packetizing and sending the audio to the server.
 

--- a/pymumble_py3/channels.py
+++ b/pymumble_py3/channels.py
@@ -121,6 +121,13 @@ class Channel(dict):
         self["channel_id"] = message.channel_id
         self.update(message)
 
+    def get_users(self):
+        users = []
+        for user in self.mumble_object.users.values():
+            if user["channel_id"] == self["channel_id"]:
+                users.append(user)
+        return users
+
     def update(self, message):
         """Update a channel based on an incoming message"""
         actions = dict()


### PR DESCRIPTION
I'm not sure if this kind of method is in this project's scope but I made a PR anyway.

There seems to be an issue where `channel.get_users()` does not list the pymumble user if the method is called right after moving into the channel.