### PR TITLE
IMHO, "reconnect" should catch __ALL__ sorts of connection errors.

### DIFF
--- a/pymumble_py3/mumble.py
+++ b/pymumble_py3/mumble.py
@@ -113,8 +113,12 @@ class Mumble(threading.Thread):
 
             if self.connect() >= PYMUMBLE_CONN_STATE_FAILED:  # some error occurred, exit here
                 self.ready_lock.release()
-                raise ConnectionRejectedError ("Connection error with the Mumble (murmur) Server")
-                break
+                if not self.reconnect or not self.parent_thread.is_alive():
+                    raise ConnectionRejectedError ("Connection error with the Mumble (murmur) Server")
+                    break
+                else:
+                    time.sleep(PYMUMBLE_CONNECTION_RETRY_INTERVAL)
+                    continue
 
             try:
                 self.loop()


### PR DESCRIPTION
Rationale: I'm using this stuff for a rather primitive bot which is tied
to a virtual snd_aloop device and just forwards anything to the mumble
server in the background -- and receives any input from a mumble server
in the background and forwards this "noise" to another Alsa loopback
channel.

As background process it is meant to run standalone, un-supervised and
stable.

Without this patch pymumble will just bail-out on simple network errors,
or when the mumble server is out-for-lunch-in-maintenance-mode.

IMHO, pymumble should just be penetrant and insistant with
"reconnect=True" and just should not bail out. Simply retry forever.

Other thoughts: the behaviour implemented by this patch could also be
achieved by the "calling application" by catching the asserted
exception. However, if a simple network error also bails out even with
"reconnect=True", then the purpose of "reconnect=True" is no longer
clear to me.

No flames intented, and kind thanks for your good work!