### PR TITLE
Move "STEREO" console print to debug if-condition

### DIFF
--- a/pymumble_py3/mumble.py
+++ b/pymumble_py3/mumble.py
@@ -69,8 +69,9 @@ class Mumble(threading.Thread):
         self.tokens = tokens
         self.__opus_profile = PYMUMBLE_AUDIO_TYPE_OPUS_PROFILE
         self.stereo = stereo
-
-        print(f"==== STEREO {stereo} ====")
+        
+        if debug:
+            print(f"==== STEREO {stereo} ====")
 
         self.receive_sound = False  # set to True to treat incoming audio, otherwise it is simply ignored
 


### PR DESCRIPTION
Could you move the console output for Stereo into an if-condition so that it only prints out that message in debug mode? 
The library isn't supposed to print out anything unless debug mode is active, and this change would make it consistent with that.