### PR TITLE
Ability to set a positional context and position

### DIFF
--- a/pymumble_py3/mumble.py
+++ b/pymumble_py3/mumble.py
@@ -69,7 +69,7 @@ class Mumble(threading.Thread):
         self.tokens = tokens
         self.__opus_profile = PYMUMBLE_AUDIO_TYPE_OPUS_PROFILE
         self.stereo = stereo
-
+        
         if stereo:
             self.Log.debug("Working in STEREO mode.")
         else:
@@ -524,8 +524,10 @@ class Mumble(threading.Thread):
                 except KeyError:  # sound received after user removed
                     pass
 
+                #            if len(message) - pos < size:
+                #                raise InvalidFormatError("Invalid audio frame size")
+
             pos += size  # go further in the packet, after the audio frame
-        #print(pos, len(message), terminator, struct.unpack("!f", bytes(message[-4:])))
         # TODO: get position info
 
     def set_application_string(self, string):

--- a/pymumble_py3/mumble.py
+++ b/pymumble_py3/mumble.py
@@ -69,7 +69,7 @@ class Mumble(threading.Thread):
         self.tokens = tokens
         self.__opus_profile = PYMUMBLE_AUDIO_TYPE_OPUS_PROFILE
         self.stereo = stereo
-        
+
         if stereo:
             self.Log.debug("Working in STEREO mode.")
         else:
@@ -85,6 +85,8 @@ class Mumble(threading.Thread):
 
         self.ready_lock = threading.Lock()  # released when the connection is fully established with the server
         self.ready_lock.acquire()
+
+        self.positional = None
 
     def init_connection(self):
         """Initialize variables that are local to a connection, (needed if the client automatically reconnect)"""
@@ -522,11 +524,8 @@ class Mumble(threading.Thread):
                 except KeyError:  # sound received after user removed
                     pass
 
-                #            if len(message) - pos < size:
-                #                raise InvalidFormatError("Invalid audio frame size")
-
             pos += size  # go further in the packet, after the audio frame
-
+        #print(pos, len(message), terminator, struct.unpack("!f", bytes(message[-4:])))
         # TODO: get position info
 
     def set_application_string(self, string):
@@ -656,6 +655,8 @@ class Mumble(threading.Thread):
                 userstate.texture = cmd.parameters["texture"]
             if "user_id" in cmd.parameters:
                 userstate.user_id = cmd.parameters["user_id"]
+            if "plugin_context" in cmd.parameters:
+                userstate.plugin_context = cmd.parameters["plugin_context"]
 
             self.send_message(PYMUMBLE_MSG_TYPES_USERSTATE, userstate)
             cmd.response = True

--- a/pymumble_py3/soundoutput.py
+++ b/pymumble_py3/soundoutput.py
@@ -100,6 +100,8 @@ class SoundOutput:
             sequence = VarInt(self.sequence).encode()
 
             udppacket = struct.pack('!B', header | self.target) + sequence + payload
+            if self.mumble_object.positional:
+                udppacket += struct.pack("fff", self.mumble_object.positional[0], self.mumble_object.positional[1], self.mumble_object.positional[2])
 
             self.Log.debug("audio packet to send: sequence:{sequence}, type:{type}, length:{len}".format(
                 sequence=self.sequence,

--- a/pymumble_py3/users.py
+++ b/pymumble_py3/users.py
@@ -74,7 +74,7 @@ class User(dict):
             actions["actor"] = message.actor
 
         for (field, value) in message.ListFields():
-            if field.name in ("session", "actor", "comment", "texture"):
+            if field.name in ("session", "actor", "comment", "texture", "plugin_context", "plugin_identity"):
                 continue
             actions.update(self.update_field(field.name, value))
 
@@ -207,6 +207,12 @@ class User(dict):
         params = {"session": self["session"],
                   "user_id": 0}
  
+        cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
+        self.mumble_object.execute_command(cmd)
+
+    def update_context(self, context_name):
+        params = {"session": self["session"],
+                  "plugin_context": context_name}
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 


### PR DESCRIPTION
This is a partial implementation of the positional features of mumble: it allows to set a context and to set a position for a Mumble instance. I say it is partial because it does not give access to the incoming packets positional data.

I added an `update_context` function to change a user's context but was less sure as to what the API is supposed to be for changing the position, so I just added a `positional` member on Mumble instances, that can be None, or a tuple of floats.

I needed that to implement a bot that is positioned in a game world.