### PR TITLE
add OCB2 crypto for use in UDP implementation

### DIFF
--- a/pymumble_py3/crypto.py
+++ b/pymumble_py3/crypto.py
@@ -1,0 +1,274 @@
+'''
+OCB2 crypto, broadly following the implementation from Mumble
+'''
+import struct
+import time
+
+import Crypto
+import Crypto.Random
+
+
+AES_BLOCK_SIZE = 128 // 8
+AES_KEY_SIZE_BITS = 128
+AES_KEY_SIZE_BYTES = AES_KEY_SIZE_BITS // 8
+SHIFTBITS = 63
+MAX64 = (1 << 64) - 1
+
+
+class EncryptFailedException(Exception):
+    pass
+
+
+class DecryptFailedException(Exception):
+    pass
+
+
+class CryptStateOCB2:
+    def __init__(self):
+        self.uiGood = 0
+        self.uiLate = 0
+        self.uiLost = 0
+        self.tLastGood = 0
+
+        self._raw_key = Crypto.Random.get_random_bytes(AES_KEY_SIZE_BYTES)
+        self._encrypt_iv = Crypto.Random.get_random_bytes(AES_BLOCK_SIZE)
+        self._decrypt_iv = Crypto.Random.get_random_bytes(AES_BLOCK_SIZE)
+        self._aes = None
+        self.decrypt_history = [0] * 0x100
+
+    @property
+    def raw_key(self) -> bytes:
+        return self._raw_key
+
+    @raw_key.setter
+    def raw_key(self, rkey: bytes):
+        if len(rkey) != AES_KEY_SIZE_BYTES:
+            raise Exception('raw_key has long length')
+        self._raw_key = bytes(rkey)
+        self._aes = Crypto.Cipher.AES.new(key=self.raw_key, mode=Crypto.Cipher.AES.MODE_ECB)
+
+    @property
+    def encrypt_iv(self) -> bytearray:
+        return self._encrypt_iv
+
+    @encrypt_iv.setter
+    def encrypt_iv(self, eiv: bytearray):
+        if len(eiv) != AES_BLOCK_SIZE:
+            raise Exception('encrypt_iv has long length')
+        self._encrypt_iv = bytearray(eiv)
+
+    @property
+    def decrypt_iv(self) -> bytearray:
+        return self._decrypt_iv
+
+    @decrypt_iv.setter
+    def decrypt_iv(self, div: bytearray):
+        if len(div) != AES_BLOCK_SIZE:
+            raise Exception('decrypt_iv has long length')
+        self._decrypt_iv = bytearray(div)
+
+    def is_valid(self) -> bool:
+        return self._aes is not None
+
+    def gen_key(self):
+        self.raw_key = Crypto.Random.get_random_bytes(AES_KEY_SIZE_BYTES)
+        self.encrypt_iv = Crypto.Random.get_random_bytes(AES_BLOCK_SIZE)
+        self.decrypt_iv = Crypto.Random.get_random_bytes(AES_BLOCK_SIZE)
+
+    def set_key(self, rkey: bytes, eiv: bytes, div: bytes):
+        self.raw_key = rkey
+        self.encrypt_iv = eiv
+        self.decrypt_iv = div
+
+    def encrypt(self, source: bytes) -> bytes:
+        # First, increase our IV.
+        eiv = increment_iv(self.encrypt_iv)
+        self.encrypt_iv = eiv
+
+        dst, tag = ocb_encrypt(self._aes, source, bytes(eiv))
+
+        head = bytes((eiv[0], *tag[:3]))
+        return head + dst
+
+    def decrypt(self, source: bytes, len_plain: int) -> bytes:
+        if len(source) < 4:
+            raise DecryptFailedException('Source <4 bytes long!')
+
+        div = self.decrypt_iv.copy()
+        ivbyte = source[0]
+        late = False
+        lost = 0
+
+        if (div[0] + 1) & 0xFF == ivbyte:
+            # In order as expected.
+            if ivbyte > div[0]:
+                div[0] = ivbyte
+            elif ivbyte < div[0]:
+                div[0] = ivbyte
+                div = increment_iv(div, 1)
+            else:
+                raise DecryptFailedException('ivbyte == decrypt_iv[0]')
+        else:
+            # This is either out of order or a repeat.
+            diff = ivbyte - div[0]
+            if diff > 128:
+                diff -= 256
+            elif diff < -128:
+                diff += 256
+
+            if ivbyte < div[0] and -30 < diff < 0:
+                # Late packet, but no wraparound.
+                late = True
+                lost = -1
+                div[0] = ivbyte
+            elif ivbyte > div[0] and -30 < diff < 0:
+                # Last was 0x02, here comes 0xff from last round
+                late = True
+                lost = -1
+                div[0] = ivbyte
+                div = decrement_iv(div, 1)
+            elif ivbyte > div[0] and diff > 0:
+                # Lost a few packets, but beyond that we're good.
+                lost = ivbyte - div[0] - 1
+                div[0] = ivbyte
+            elif ivbyte < div[0] and diff > 0:
+                # Lost a few packets, and wrapped around
+                lost = 0x100 - div[0] + ivbyte - 1
+                div[0] = ivbyte
+                div = increment_iv(div, 1)
+            else:
+                raise DecryptFailedException('Lost too many packets?')
+
+            if self.decrypt_history[div[0]] == div[1]:
+                raise DecryptFailedException('decrypt_iv in history')
+
+        dst, tag = ocb_decrypt(self._aes, source[4:], bytes(div), len_plain)
+
+        if tag[:3] != source[1:4]:
+            raise DecryptFailedException('Tag did not match!')
+
+        self.decrypt_history[div[0]] = div[1]
+
+        if not late:
+            self.decrypt_iv = div
+        else:
+            self.uiLate += 1
+
+        self.uiGood += 1
+        self.uiLost += lost
+
+        self.tLastGood = time.perf_counter()
+
+        return dst
+
+
+def ocb_encrypt(aes, plain, nonce, *, insecure=False):
+    delta = aes.encrypt(nonce)
+    checksum = bytes(AES_BLOCK_SIZE)
+    encrypted_blocks = []
+    plain_block = b''
+
+    pos = 0
+    while len(plain) - pos > AES_BLOCK_SIZE:
+        plain_block = plain[pos:pos + AES_BLOCK_SIZE]
+        delta = S2(delta)
+        encrypted_block = xor(delta, aes.encrypt(xor(delta, plain_block)))
+        checksum = xor(checksum, plain_block)
+
+        pos += AES_BLOCK_SIZE
+        encrypted_blocks.append(encrypted_block)
+
+    # Counter-cryptanalysis described in section 9 of https://eprint.iacr.org/2019/311
+    # For an attack, the second to last block (i.e. the last iteration of this loop)
+    # must be all 0 except for the last byte (which may be 0 - 128).
+    if not insecure and bytes(plain_block[:-1]) == bytes(AES_BLOCK_SIZE - 1):
+        raise EncryptFailedException('Insecure input block: ' +
+                                     'see section 9 of https://eprint.iacr.org/2019/311')
+
+    len_remaining = len(plain) - pos
+    delta = S2(delta)
+    pad_in = struct.pack('>QQ', 0, len_remaining * 8)
+    pad = aes.encrypt(xor(pad_in, delta))
+    plain_padded = plain[pos:] + pad[len_remaining - AES_BLOCK_SIZE:]
+
+    checksum = xor(checksum, plain_padded)
+    encrypted_block = xor(pad, plain_padded)
+    encrypted_blocks.append(encrypted_block)
+
+    delta = xor(delta, S2(delta))
+    tag = aes.encrypt(xor(delta, checksum))
+
+    encrypted = b''.join(encrypted_blocks)
+    return encrypted, tag
+
+
+def ocb_decrypt(aes, encrypted, nonce, len_plain, *, insecure=False):
+    delta = aes.encrypt(nonce)
+    checksum = bytes(AES_BLOCK_SIZE)
+    plain_blocks = []
+
+    pos = 0
+    while len_plain - pos > AES_BLOCK_SIZE:
+        encrypted_block = encrypted[pos:pos + AES_BLOCK_SIZE]
+        delta = S2(delta)
+        tmp = aes.decrypt(xor(delta, encrypted_block))
+        plain_block = xor(delta, tmp)
+        checksum = xor(checksum, plain_block)
+
+        plain_blocks.append(plain_block)
+        pos += AES_BLOCK_SIZE
+
+    len_remaining = len_plain - pos
+    delta = S2(delta)
+    pad_in = struct.pack('>QQ', 0, len_remaining * 8)
+    pad = aes.encrypt(xor(pad_in, delta))
+    encrypted_zeropad = encrypted[pos:] + bytes(AES_BLOCK_SIZE - len_remaining)
+    plain_padded = xor(encrypted_zeropad, pad)
+
+    checksum = xor(checksum, plain_padded)
+    plain_block = plain_padded[:len_remaining]
+    plain_blocks.append(plain_block)
+
+    # Counter-cryptanalysis described in section 9 of https://eprint.iacr.org/2019/311
+    # In an attack, the decrypted last block would need to equal `delta ^ len(128)`.
+    # With a bit of luck (or many packets), smaller values than 128 (i.e. non-full blocks) are also
+    # feasible, so we check `plain_padded` instead of `plain`.
+    # Since our `len` only ever modifies the last byte, we simply check all remaining ones.
+    if not insecure and plain_padded[:-1] == delta[:-1]:
+        raise DecryptFailedException('Possibly tampered/able block, discarding.')
+
+    delta = xor(delta, S2(delta))
+    tag = aes.encrypt(xor(delta, checksum))
+
+    plain = b''.join(plain_blocks)
+    return plain, tag
+
+
+def increment_iv(iv: bytearray, start: int = 0) -> bytearray:
+    for i in range(start, AES_BLOCK_SIZE):
+        iv[i] = (iv[i] + 1) % 0x100
+        if iv[i] != 0:
+            break
+    return iv
+
+
+def decrement_iv(iv: bytearray, start: int = 0) -> bytearray:
+    for i in range(start, AES_BLOCK_SIZE):
+        iv[i] = (iv[i] - 1) % 0x100
+        if iv[i] != 0xFF:
+            break
+    return iv
+
+
+def xor(a: bytes, b: bytes) -> bytes:
+    return bytes(aa ^ bb for aa, bb in zip(a, b))
+
+
+def S2(block: bytes) -> bytes:
+    ll, uu = struct.unpack('>QQ', block)
+    carry = ll >> 63
+    block = struct.pack('>QQ',
+                        ((ll << 1) | (uu >> 63)) & MAX64,
+                        ((uu << 1) ^ (carry * 0x87)) & MAX64)
+    return block
+

--- a/pymumble_py3/crypto.py
+++ b/pymumble_py3/crypto.py
@@ -100,9 +100,6 @@ class CryptStateOCB2:
             raise Exception('decrypt_iv has wrong length')
         self._decrypt_iv = bytearray(div)
 
-    def is_valid(self) -> bool:
-        return self._aes is not None
-
     def gen_key(self):
         """
         Randomly generate new keys

--- a/pymumble_py3/test_crypto.py
+++ b/pymumble_py3/test_crypto.py
@@ -1,0 +1,191 @@
+'''
+Ported from Mumble src/tests/TestCrypt/TestCrypt.cpp
+
+=============================================================
+
+Copyright 2005-2020 The Mumble Developers. All rights reserved.
+Use of this source code is governed by a BSD-style license
+that can be found in the LICENSE file at the root of the
+Mumble source tree or at <https://www.mumble.info/LICENSE>.
+'''
+
+import pytest
+
+from .crypto import CryptStateOCB2, AES_BLOCK_SIZE, EncryptFailedException, DecryptFailedException
+from .crypto import ocb_encrypt, ocb_decrypt
+
+
+@pytest.fixture()
+def rawkey():
+    return bytes((0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0a,0x0b,0x0c,0x0d,0x0e,0x0f))
+
+
+@pytest.fixture()
+def nonce():
+    return bytes((0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00))
+
+
+def test_reverserecovery():
+    enc = CryptStateOCB2()
+    dec = CryptStateOCB2()
+    enc.gen_key()
+
+    # For our testcase, we're going to FORCE iv
+    enc.encrypt_iv = bytes((0x55,) * AES_BLOCK_SIZE)
+    dec.set_key(enc.raw_key, enc.decrypt_iv, enc.encrypt_iv)
+
+    secret = "abcdefghi".encode('ascii')
+
+    crypted = [enc.encrypt(secret) for _ in range(128)]
+
+    i = 0
+    for crypt in reversed(crypted[-30:]):
+        print(i)
+        i += 1
+        dec.decrypt(crypt, len(secret))
+    for crypt in reversed(crypted[:-30]):
+        with pytest.raises(DecryptFailedException):
+            dec.decrypt(crypt, len(secret))
+    for crypt in reversed(crypted[-30:]):
+        with pytest.raises(DecryptFailedException):
+            dec.decrypt(crypt, len(secret))
+
+    # Extensive replay attack test
+    crypted = [enc.encrypt(secret) for _ in range(512)]
+
+    for crypt in crypted:
+        decr = dec.decrypt(crypt, len(secret))
+    for crypt in crypted:
+        with pytest.raises(DecryptFailedException):
+            dec.decrypt(crypt, len(secret))
+
+
+def test_ivrecovery():
+    enc = CryptStateOCB2()
+    dec = CryptStateOCB2()
+    enc.gen_key()
+
+    # For our testcase, we're going to FORCE iv
+    enc.encrypt_iv = bytes((0x55,) * AES_BLOCK_SIZE)
+    dec.set_key(enc.raw_key, enc.decrypt_iv, enc.encrypt_iv)
+
+    secret = "abcdefghi".encode('ascii')
+
+    crypted = enc.encrypt(secret)
+
+    # Can decrypt
+    decr = dec.decrypt(crypted, len(secret))
+    # ... correctly.
+    assert secret == decr
+
+    # But will refuse to reuse same IV.
+    with pytest.raises(DecryptFailedException):
+        dec.decrypt(crypted, len(secret))
+
+    # Recover from lost packet.
+    for i in range(16):
+        crypted = enc.encrypt(secret)
+    decr = dec.decrypt(crypted, len(secret))
+
+    # Wraparound.
+    for i in range(128):
+        dec.uiLost = 0
+        for j in range(15):
+            crypted = enc.encrypt(secret)
+        decr = dec.decrypt(crypted, len(secret))
+        assert dec.uiLost == 14
+
+    assert enc.encrypt_iv == dec.decrypt_iv
+
+    # Wrap too far
+    for i in range(257):
+        crypted = enc.encrypt(secret);
+
+    with pytest.raises(DecryptFailedException):
+        dec.decrypt(crypted, len(secret))
+
+    # Sync it
+    dec.decrypt_iv = enc.encrypt_iv
+    crypted = enc.encrypt(secret)
+
+    decr = dec.decrypt(crypted, len(secret))
+
+def test_testvectors(rawkey):
+    # Test vectors are from draft-krovetz-ocb-00.txt
+    cs = CryptStateOCB2()
+    cs.set_key(rawkey, rawkey, rawkey)
+
+    _, tag = ocb_encrypt(cs._aes, bytes(), rawkey)
+
+    blanktag = bytes((0xBF,0x31,0x08,0x13,0x07,0x73,0xAD,0x5E,0xC7,0x0E,0xC6,0x9E,0x78,0x75,0xA7,0xB0))
+    assert len(blanktag) == AES_BLOCK_SIZE
+
+    assert tag == blanktag
+
+    source = bytes(range(40))
+    crypt, tag = ocb_encrypt(cs._aes, source, rawkey)
+    longtag = bytes((0x9D,0xB0,0xCD,0xF8,0x80,0xF7,0x3E,0x3E,0x10,0xD4,0xEB,0x32,0x17,0x76,0x66,0x88))
+    crypted = bytes((0xF7,0x5D,0x6B,0xC8,0xB4,0xDC,0x8D,0x66,0xB8,0x36,0xA2,0xB0,0x8B,0x32,0xA6,0x36,0x9F,0x1C,0xD3,0xC5,0x22,0x8D,0x79,0xFD,
+                     0x6C,0x26,0x7F,0x5F,0x6A,0xA7,0xB2,0x31,0xC7,0xDF,0xB9,0xD5,0x99,0x51,0xAE,0x9C))
+
+    assert tag == longtag
+    assert crypt[:len(crypted)] == crypted
+
+
+def test_authcrypt(rawkey, nonce):
+    cs = CryptStateOCB2()
+    for ll in range(128):
+        cs.set_key(rawkey, nonce, nonce)
+        src = bytes((i + 1 for i in range(ll)))
+
+        encrypted, enctag = ocb_encrypt(cs._aes, src, nonce)
+        decrypted, dectag = ocb_decrypt(cs._aes, encrypted, nonce, len(src))
+
+        assert enctag == dectag
+        assert src == decrypted
+
+
+def test_xexstarAttack(rawkey, nonce):
+    ''' Test prevention of the attack described in section 4.1 of https://eprint.iacr.org/2019/311 '''
+    cs = CryptStateOCB2()
+    cs.set_key(rawkey, nonce, nonce)
+
+    # Set first block to `len(secondBlock)`
+    # Set second block to arbitrary value
+    src = bytearray(AES_BLOCK_SIZE) + bytearray([42] * AES_BLOCK_SIZE)
+    src[AES_BLOCK_SIZE - 1] = AES_BLOCK_SIZE * 8
+    print(src)
+
+    with pytest.raises(EncryptFailedException):
+        ocb_encrypt(cs._aes, src, nonce)
+    encrypted, enctag = ocb_encrypt(cs._aes, src, nonce, insecure=True)
+
+    # Perform the attack
+    encrypted = bytearray(encrypted)
+    enctag = bytearray(enctag)
+    encrypted[AES_BLOCK_SIZE - 1] ^= AES_BLOCK_SIZE * 8
+    for i in range(AES_BLOCK_SIZE):
+        enctag[i] = src[AES_BLOCK_SIZE + i] ^ encrypted[AES_BLOCK_SIZE + i]
+
+    with pytest.raises(DecryptFailedException):
+        dc, dct = ocb_decrypt(cs._aes, encrypted, nonce, AES_BLOCK_SIZE)
+        print(dc, dct, enctag == dct)
+    decrypted, dectag = ocb_decrypt(cs._aes, encrypted, nonce, AES_BLOCK_SIZE, insecure=True)
+
+    # Verify forged tag (should match if attack is properly implemented)
+    assert enctag == dectag
+
+
+def test_tamper(rawkey, nonce):
+    cs = CryptStateOCB2()
+    cs.set_key(rawkey, nonce, nonce)
+
+    msg = "It was a funky funky town!".encode('ascii')
+    encrypted = bytearray(cs.encrypt(msg))
+
+    for i in range(len(msg) * 8):
+        encrypted[i // 8] ^= 1 << (i % 8)
+        with pytest.raises(DecryptFailedException):
+            cs.decrypt(encrypted, len(msg))
+        encrypted[i // 8] ^= 1 << (i % 8)
+    decrypted = cs.decrypt(encrypted, len(msg))


### PR DESCRIPTION
Based on the last comment in #66, I took a look at Mumble's AES-OCB2 implementation and put together a quick python implementation based on pycryptodome's AES and Mumble's test suite.

It probably still needs some edits for style etc., but it passes the tests so I figured I'd ask for input and gauge interest.