### PR TITLE
pycryptodome compatibility

### DIFF
--- a/pymumble_py3/crypto.py
+++ b/pymumble_py3/crypto.py
@@ -46,7 +46,7 @@ class CryptStateOCB2:
         tLastGood
     """
     _raw_key: bytes         # AES key; access through `raw_key` property
-    _aes: AES.AESCipher     # pycrypto AES cipher object, replaced when `raw_key` is changed
+    _aes: object            # pycrypto AES cipher object, replaced when `raw_key` is changed
     _encrypt_iv: bytearray  # IV for encryption, access through `encrypt_iv` property
     _decrypt_iv: bytearray  # IV for decryption, access through `decrypt_iv` property
     decrypt_history: bytearray  # History of previous decrypt_iv values
@@ -230,7 +230,7 @@ class CryptStateOCB2:
         return dst
 
 
-def ocb_encrypt(aes: AES.AESCipher,
+def ocb_encrypt(aes: object,
                 plain: bytes,
                 nonce: bytes,
                 *,
@@ -289,7 +289,7 @@ def ocb_encrypt(aes: AES.AESCipher,
     return encrypted, tag
 
 
-def ocb_decrypt(aes: AES.AESCipher,
+def ocb_decrypt(aes: object,
                 encrypted: bytes,
                 nonce: bytes,
                 len_plain: int,


### PR DESCRIPTION
pycryptodome is supposed to be a drop-in replacement for pycrypto.
However the AES.AESCipher class was removed in https://github.com/Legrandin/pycryptodome/commit/e9adec93c7243d2ee16f748090d5a102866d30c5, breaking compatibility with pycrypto

We can easily fix pymumble for this accidental breakage by just not referring to AESCipher for the type hints, and letting it be object instead