### PR TITLE
UDP encryption fix

### DIFF
--- a/pymumble_py3/crypto.py
+++ b/pymumble_py3/crypto.py
@@ -282,7 +282,7 @@ def ocb_encrypt(aes: object,
 
     checksum = xor(checksum, plain_block)
     encrypted_block = xor(pad, plain_block)
-    encrypted[pos:] = encrypted_block
+    encrypted[pos:] = encrypted_block[0:len_remaining]
 
     delta = xor(delta, S2(delta))
     tag = aes.encrypt(xor(delta, checksum))

--- a/pymumble_py3/crypto.py
+++ b/pymumble_py3/crypto.py
@@ -142,7 +142,7 @@ class CryptStateOCB2:
         head = bytes((eiv[0], *tag[:3]))
         return head + dst
 
-    def decrypt(self, source: bytes, len_plain: int) -> bytes:
+    def decrypt(self, source: bytes, len_plain: int | None = None) -> bytes:
         """
         Decrypt a message
 
@@ -161,6 +161,9 @@ class CryptStateOCB2:
         """
         if len(source) < 4:
             raise DecryptFailedException('Source <4 bytes long!')
+
+        if not len_plain:
+            len_plain = len(source) - 4  # The entire packet length, minus the header
 
         div = self.decrypt_iv.copy()
         ivbyte = source[0]

--- a/pymumble_py3/crypto.py
+++ b/pymumble_py3/crypto.py
@@ -142,7 +142,7 @@ class CryptStateOCB2:
         head = bytes((eiv[0], *tag[:3]))
         return head + dst
 
-    def decrypt(self, source: bytes, len_plain: int | None = None) -> bytes:
+    def decrypt(self, source: bytes) -> bytes:
         """
         Decrypt a message
 
@@ -162,8 +162,7 @@ class CryptStateOCB2:
         if len(source) < 4:
             raise DecryptFailedException('Source <4 bytes long!')
 
-        if not len_plain:
-            len_plain = len(source) - 4  # The entire packet length, minus the header
+        len_plain = len(source) - 4  # The entire packet length, minus the header
 
         div = self.decrypt_iv.copy()
         ivbyte = source[0]

--- a/pymumble_py3/mumble.py
+++ b/pymumble_py3/mumble.py
@@ -333,7 +333,7 @@ class Mumble(threading.Thread):
         except socket.error:
             pass
 
-        receive_buffer = self.ocb.decrypt(encrypted_buffer, len(encrypted_buffer))
+        receive_buffer = self.ocb.decrypt(encrypted_buffer)
 
         while len(receive_buffer) >= 6:  # header is present (type + length)
             self.Log.debug("read control connection")

--- a/pymumble_py3/soundoutput.py
+++ b/pymumble_py3/soundoutput.py
@@ -113,7 +113,7 @@ class SoundOutput:
             ))
 
             if self.mumble_object.udp_active:
-                self.mumble_object.send_udp(udp_packet)
+                self.mumble_object.send_packet_udp(udp_packet)
             else:
                 tcp_packet = struct.pack("!HL", PYMUMBLE_MSG_TYPES_UDPTUNNEL, len(udp_packet)) + udp_packet  # encapsulate in tcp tunnel
 


### PR DESCRIPTION
The main change I made is limiting the last encrypted block, appended to the encrypted string, to the actual remaining length.
I think previously some padding bytes were added and this caused a wrong checksum calculation, so the server were refusing most of the packets because of the wrong header tag (derived from the checksum).

To fix this I recompiled the Mumble server to add some useful log to find the error, but what led me to the solution was this very old implementation, found between Mumble issues, reported as working (at the time at least):
https://github.com/ianling/mumpy/blob/dev/mumpy/mumblecrypto.py

This is my first public contribution, I've put the same link in the commit description as a credit, I don't know if it's needed or if this is enough.

The last two changes are needed just to get everything at a minimum working stage:
* I added a default length to the decrypt method, which is the packet length minus the header (1 byte of the iv, 3 bytes of tag)~~, sometimes along the code it wasn't specified as an argument and that made the library crash~~ Edit: manual parameter specification has been completely removed as suggested by @dkirker since it was error prone;
* I renamed a method call in soundoutput, since send_udp wasn't an existing method.

After the changes, all the tests in test_crypto.py still passes and Mumble reports the UDP protocol as working (the number of the packet sent is increasing while reproducing music).


